### PR TITLE
Refactor readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,60 @@
 # Medusa File Google Cloud Storage Images
-Google cloud storage plugin for medusajs
 
+Google Cloud Platform (GCP) storage plugin for Medusa.js
 
-Usage
+## Prerequisites
 
-Open your `medusa.config.js` and add the below configuration
+- [Medusa backend](https://docs.medusajs.com/development/backend/install/)
+- [Google Cloud Platform (GCP)](https://cloud.google.com/)
+
+## How to install
+
+1. Run the following command in the directory of your Medusa backend:
+
+```
+npm install medusa-plugin-gcp
+```
+
+2. Add following environment variables into your `.env`:
+
+```
+GCP_BUCKET=<YOUR_BUCKET_NAME>
+GCP_PRIVATE_KEY=<YOUR_SERVICE_ACCOUNT_PRIVATE_KEY>
+GCP_CLIENT_EMAIL=<YOUR_SERVICE_ACCOUNT_IAM_EMAIL>
+```
+
+3. Open your `medusa.config.js` and add the below configuration:
 
 ```js
 module.exports = {
   plugins: [
     ...otherMedusaPlugins,
     {
-      resolve: `medusa-file-gcp`,
+      resolve: `medusa-plugin-gcp`,
       options: {
         bucket: process.env.GCP_BUCKET,
         credentials: {
-            private_key: "----BEGIN PRIVATE KEY", 
-            client_email: "myemail@example.com"
+          private_key: process.env.GCP_PRIVATE_KEY,
+          client_email: process.env.GCP_CLIENT_EMAIL,
         },
       },
     },
-  ]
-}
+  ],
+};
 ```
+
+## Test the plugin
+
+1. Run your Medusa backend:
+
+```
+npm run dev
+```
+
+2. Try to upload an image for a product using Medusa's admin interface. The image should appear into your storage bucket.
+
+## Additional resources
+
+- [GCP Storage Buckets](Bucketshttps://cloud.google.com/storage/docs/creating-buckets/)
+- [GCP Service Accounts](https://cloud.google.com/iam/docs/service-account-overview/)
+- [@google-cloud/storage (package)](https://www.npmjs.com/package/@google-cloud/storage/)


### PR DESCRIPTION
I just built a demo store on top of Medusa with GCP storage. Thanks for the plugin, it's awesome that it wasn't necessary to build some basic functionality like this from scratch!

Anyways, the documentation lacks some necessary information and the plugin name in the configuration seems to be wrong which leads to problems when trying to setup the plugin. Hope this refactoring of `README` could help others who might otherwise face similar problems as me.

**About the plugin name:** Not sure if the plugin is supposed to be named `medusa-file-gcp` instead of `medusa-plugin-gcp` but only the latter works at the moment. The current repository name and the current README configuration both differ from the plugin name Medusa configuration requires.